### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#TTLocationHandler
+# TTLocationHandler
 
 This is the evolution of my experimentation and testing the best manner of use of location services in iOS. It started with a base derived from the code and all that I learned from a series by Mark at The Long Weekend Website.
 
@@ -9,13 +9,13 @@ That code was released "via an MIT-style license (=do whatever you want with it,
 
 In this repository, you will find one class header and implementation that you want to import if you intend to try it in your own project. The entire class is comprised of the files TTLocationHandler.h and TTLocationHandler.m. The other classes are all just a quick mashup to demonstrate use and check that all works as intended.
 
-##Event Handling Notes:  
+## Event Handling Notes:  
 - Handler receives the location events from the locationManager, checks for accuracy and time since last event.  
 - If the last event was stored a set interval earlier, and is within the required accuracy, the location info is accepted and saved.  
 - Saving a location from a location event is done in a property of the handler and in the standardUserDefaults. Saving in the defaults allows any class in the project to get the most recent location without having to import, hold reference to, or even to know anything  at all about the locationHandler class.  
 - If the time since previous saved event is outside our parameters and the new location is inaccurate, it is stored in a queue array and considered for acceptance only if another more accurate location isn't received. Ten seconds is allowed to wait for more accurate event, and max tries of 10 before giving up and best available is accepted. 
 
-##Power usage and Background Operation Notes:  
+## Power usage and Background Operation Notes:  
 - The default is allow continuous updating of location when the application is in foreground. This can be set on or off.  
 - The default is to switch to significantUpdates only when in the background. There is a setting for continuous updates in background when the device is plugged into external power. 
 - You can also set continuesUpdatingOnBattery. Use this responsibly as it will impact batter life considerably.  


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
